### PR TITLE
ci: remove automated macOS testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,8 +8,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
-          - macos-10.15
+          - ubuntu-18.04          
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code and submodule


### PR DESCRIPTION
a macOS action minute costs 10 times more than linux and we run everything in containers anyway, so there is no real benefit in having these extra tests