### PR TITLE
chore: store files in .tofnd directory

### DIFF
--- a/src/gg20/service/mod.rs
+++ b/src/gg20/service/mod.rs
@@ -3,7 +3,7 @@
 use super::mnemonic::{file_io::FileIo, Cmd};
 use super::proto;
 use super::types::{KeySharesKv, MnemonicKv, DEFAULT_MNEMONIC_KV_NAME, DEFAULT_SHARE_KV_NAME};
-use crate::TofndError;
+use crate::{TofndError, DEFAULT_PATH_ROOT};
 use std::path::PathBuf;
 
 #[cfg(feature = "malicious")]
@@ -28,7 +28,7 @@ pub async fn new_service(
     let mut gg20 = Gg20Service {
         shares_kv: KeySharesKv::new(DEFAULT_SHARE_KV_NAME),
         mnemonic_kv: MnemonicKv::new(DEFAULT_MNEMONIC_KV_NAME),
-        io: FileIo::new(PathBuf::new()),
+        io: FileIo::new(PathBuf::from(DEFAULT_PATH_ROOT)),
         safe_keygen: true,
         #[cfg(feature = "malicious")]
         behaviours,

--- a/src/kv_manager/mod.rs
+++ b/src/kv_manager/mod.rs
@@ -17,7 +17,7 @@ type Responder<T> = oneshot::Sender<Result<T, Box<dyn Error + Send + Sync>>>;
 const DEFAULT_RESERV: &str = "";
 
 // default kv path
-const DEFAULT_KV_PATH: &str = ".kvstore";
+const DEFAULT_KV_PATH: &str = "kvstore";
 
 // "actor" pattern (KV is the "handle"): https://ryhl.io/blog/actors-with-tokio/
 // see also https://tokio.rs/tokio/tutorial/channels
@@ -30,7 +30,9 @@ where
     V: Debug + Send + Sync + Serialize + DeserializeOwned,
 {
     pub fn new(kv_name: &str) -> Self {
-        let kv_path = PathBuf::from(DEFAULT_KV_PATH).join(kv_name);
+        let kv_path = PathBuf::from(DEFAULT_PATH_ROOT)
+            .join(DEFAULT_KV_PATH)
+            .join(kv_name);
         // use to_string_lossy() instead of to_str() to avoid handling Option<&str>
         let kv_path = kv_path.to_string_lossy().to_string();
         Self::with_db_name(kv_path)
@@ -119,6 +121,8 @@ enum Command<V> {
     },
 }
 use Command::*;
+
+use crate::DEFAULT_PATH_ROOT;
 
 /// Returns the db with name `db_name`, or creates a new if such DB does not exist
 /// Default path DB path is the executable's directory; The caller can specify a

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,8 @@ pub fn warn_for_malicious_build() {
     warn!("WARNING: THIS tofnd BINARY AS COMPILED IN 'MALICIOUS' MODE.  MALICIOUS BEHAVIOUR IS INTENTIONALLY INSERTED INTO SOME MESSAGES.  THIS BEHAVIOUR WILL CAUSE OTHER tofnd PROCESSES TO IDENTIFY THE CURRENT PROCESS AS MALICIOUS.");
 }
 
+const DEFAULT_PATH_ROOT: &str = ".tofnd";
+
 #[tokio::main]
 async fn main() -> Result<(), TofndError> {
     // set up log subscriber


### PR DESCRIPTION
All tofnd storage is now inside `.tofnd` directory:
* `.kvstore -> .tofnd/kvstore`
* `[import|export] ->.tofnd/[import|export]`

Tested on a local cluster to verify new location of files.