### PR TITLE
fix(logs): flatten log events

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ fn set_up_logs() {
         .without_time()
         .with_target(false)
         .with_current_span(false)
+        .flatten_event(true) // make logs complient with datadog
         .init();
 }
 


### PR DESCRIPTION
Datadog is happy when there is a field "message" at the top level of log's JSON. By default, tracing-subscriber puts "message" field in "fields" field. `flatten_event(true)` seems to do the trick.
https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#attribute-types-and-aliasing