### PR TITLE
chore(grpc): classify serialization faults as non-malicious

### DIFF
--- a/src/gg20/proto_helpers.rs
+++ b/src/gg20/proto_helpers.rs
@@ -79,8 +79,7 @@ impl proto::MessageOut {
 
 fn fault_to_crime(f: &Fault) -> ProtoCrimeType {
     match f {
-        Fault::MissingMessage => ProtoCrimeType::NonMalicious,
-        Fault::CorruptedMessage => ProtoCrimeType::Unspecified,
+        Fault::MissingMessage | Fault::CorruptedMessage => ProtoCrimeType::NonMalicious,
         Fault::ProtocolFault => ProtoCrimeType::Malicious,
     }
 }

--- a/src/tests/malicious/keygen_test_cases.rs
+++ b/src/tests/malicious/keygen_test_cases.rs
@@ -108,7 +108,7 @@ impl TestCase {
         self.expected_keygen_faults = CriminalList {
             criminals: vec![Criminal {
                 party_uid: ((b'A' + index as u8) as char).to_string(),
-                crime_type: CrimeType::Unspecified as i32,
+                crime_type: CrimeType::NonMalicious as i32,
             }],
         };
         self

--- a/src/tests/malicious/sign_test_cases.rs
+++ b/src/tests/malicious/sign_test_cases.rs
@@ -157,7 +157,7 @@ impl TestCase {
         self.expected_sign_faults = CriminalList {
             criminals: vec![Criminal {
                 party_uid: ((b'A' + index as u8) as char).to_string(),
-                crime_type: CrimeType::Unspecified as i32,
+                crime_type: CrimeType::NonMalicious as i32,
             }],
         };
         self


### PR DESCRIPTION
Don't use `Unexpected` crime type and classify serialization faults as non-malicious (like timeouts). Axelar-core's policy to penalize faults, [here](https://github.com/axelarnetwork/axelar-core/blob/e10a446b6e4124c0f0ffe2ae59daf506f42453a7/x/tss/keeper/keeperSign.go#L266-L274).