### PR TITLE
chore(grpc): change type of `my_party_index` and `threshold` to `uint32`

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -659,8 +659,8 @@ async fn execute_keygen(
             new_key_uid: new_key_uid.to_string(),
             party_uids: party_uids.to_owned(),
             party_share_counts: party_share_counts.to_owned(),
-            my_party_index: i32::try_from(i).unwrap(),
-            threshold: i32::try_from(threshold).unwrap(),
+            my_party_index: u32::try_from(i).unwrap(),
+            threshold: u32::try_from(threshold).unwrap(),
         };
         let delivery = keygen_delivery.clone();
         let handle = tokio::spawn(async move {
@@ -688,7 +688,7 @@ async fn execute_keygen(
         party_uids: party_uids.to_owned(),
         party_share_counts: party_share_counts.to_owned(),
         my_party_index: 0, // return keygen for first party. Might need to change index before using
-        threshold: i32::try_from(threshold).unwrap(),
+        threshold: u32::try_from(threshold).unwrap(),
     };
     (parties, results, init)
 }
@@ -736,7 +736,7 @@ async fn execute_recover(
     // create keygen init for recovered party
     let key_uid = keygen_init.new_key_uid.clone();
 
-    keygen_init.my_party_index = recover_party_index as i32;
+    keygen_init.my_party_index = recover_party_index as u32;
     parties[recover_party_index]
         .execute_recover(keygen_init, keygen_outputs[recover_party_index].clone())
         .await;


### PR DESCRIPTION
Change `my_party_index` and `my_party_index` from `int32` to `uint32` according to [NCC#2](https://github.com/axelarnetwork/tofnd/issues/147) audit in tofnd.

- [x] don't merge before https://github.com/axelarnetwork/grpc-protobuf/pull/7 is merged and checkout submodule's main
- [x] coordinate merge with https://github.com/axelarnetwork/axelar-core/pull/851