### PR TITLE
feat(multisig): key presence

### DIFF
--- a/src/multisig/key_presence.rs
+++ b/src/multisig/key_presence.rs
@@ -1,0 +1,36 @@
+//! This module handles the key_presence gRPC.
+//! Request includes [proto::message_in::Data::KeyPresenceRequest] struct and encrypted recovery info.
+//! The recovery info is decrypted by party's mnemonic seed and saved in the KvStore.
+
+use super::service::MultisigService;
+
+// logging
+use tracing::info;
+
+// error handling
+use crate::{proto, TofndResult};
+
+impl MultisigService {
+    pub(super) async fn handle_key_presence(
+        &self,
+        request: proto::KeyPresenceRequest,
+    ) -> TofndResult<proto::key_presence_response::Response> {
+        // check if mnemonic is available
+        let _ = self.kv_manager.seed().await?;
+
+        // check if requested key exists
+        if self.kv_manager.kv().exists(&request.key_uid).await? {
+            info!(
+                "Found session-id {} in kv store during multisig key presence check",
+                request.key_uid
+            );
+            Ok(proto::key_presence_response::Response::Present)
+        } else {
+            info!(
+                "Did not find session-id {} in kv store during multisig key presence check",
+                request.key_uid
+            );
+            Ok(proto::key_presence_response::Response::Absent)
+        }
+    }
+}

--- a/src/multisig/mod.rs
+++ b/src/multisig/mod.rs
@@ -1,3 +1,4 @@
+mod key_presence;
 mod keygen;
 pub mod service;
 mod sign;

--- a/src/multisig/service.rs
+++ b/src/multisig/service.rs
@@ -19,6 +19,28 @@ pub fn new_service(kv_manager: KvManager) -> impl proto::multisig_server::Multis
 
 #[tonic::async_trait]
 impl proto::multisig_server::Multisig for MultisigService {
+    async fn key_presence(
+        &self,
+        request: tonic::Request<proto::KeyPresenceRequest>,
+    ) -> Result<Response<proto::KeyPresenceResponse>, Status> {
+        let request = request.into_inner();
+
+        let response = match self.handle_key_presence(request).await {
+            Ok(res) => {
+                info!("Key presence check completed succesfully!");
+                res
+            }
+            Err(err) => {
+                error!("Unable to complete key presence check: {}", err);
+                proto::key_presence_response::Response::Fail
+            }
+        };
+
+        Ok(Response::new(proto::KeyPresenceResponse {
+            response: response as i32,
+        }))
+    }
+
     async fn keygen(
         &self,
         request: tonic::Request<proto::KeygenRequest>,


### PR DESCRIPTION
Quick and dirty key presence RPC for `mulitsig`.

`KeyPresence` for `mulitisig` is exactly the same as in `Gg20`: we check if a `key` exists in the kvstore. This can be improved in several ways:
1. create a `common` gRPC module to wrap all common functionalities between `multisig` and `gg20`.
2. distinguish between `multisig` and `gg20` keys so that we can't have false-positives when axelar-core asks for a `multisig` key, but a `gg20` key with this name exists - and vice versa.

Todos:
- [x] merge https://github.com/axelarnetwork/grpc-protobuf/pull/10
- [x] create issues with the option we mostly want to follow in the future https://github.com/axelarnetwork/tofnd/issues/220
