### PR TITLE
feat(multisig): create keys on-the-fly 

### DIFF
--- a/src/gg20/sign/init.rs
+++ b/src/gg20/sign/init.rs
@@ -27,7 +27,7 @@ impl Gg20Service {
     pub(super) async fn handle_sign_init(
         &self,
         in_stream: &mut tonic::Streaming<proto::MessageIn>,
-        mut out_stream: &mut mpsc::UnboundedSender<Result<proto::MessageOut, Status>>,
+        out_stream: &mut mpsc::UnboundedSender<Result<proto::MessageOut, Status>>,
         sign_span: Span,
     ) -> TofndResult<(SignInitSanitized, PartyInfo)> {
         let msg_type = in_stream
@@ -47,7 +47,7 @@ impl Gg20Service {
             Ok(value) => value.try_into()?,
             Err(err) => {
                 // if no such session id exists, send a message to client that indicates that recovery is needed and stop sign
-                Self::send_kv_store_failure(&mut out_stream)?;
+                Self::send_kv_store_failure(out_stream)?;
                 let err = anyhow!("Unable to find session-id {} in kv store. Issuing share recovery and exit sign {:?}", sign_init.key_uid, err);
                 return Err(err);
             }

--- a/src/multisig/key_presence.rs
+++ b/src/multisig/key_presence.rs
@@ -1,6 +1,5 @@
 //! This module handles the key_presence gRPC.
 //! Request includes [proto::message_in::Data::KeyPresenceRequest] struct and encrypted recovery info.
-//! The recovery info is decrypted by party's mnemonic seed and saved in the KvStore.
 
 use super::service::MultisigService;
 
@@ -18,6 +17,9 @@ impl MultisigService {
         // check if mnemonic is available
         let _ = self.kv_manager.seed().await?;
 
+        // key presence for multisig always returns `Present`.
+        // this is done in order to not break compatibility with axelar-core
+        // TODO: better handling for multisig key presence.
         info!(
             "[{}] Executing key presence check for multisig",
             request.key_uid

--- a/src/multisig/key_presence.rs
+++ b/src/multisig/key_presence.rs
@@ -18,19 +18,10 @@ impl MultisigService {
         // check if mnemonic is available
         let _ = self.kv_manager.seed().await?;
 
-        // check if requested key exists
-        if self.kv_manager.kv().exists(&request.key_uid).await? {
-            info!(
-                "Found session-id {} in kv store during multisig key presence check",
-                request.key_uid
-            );
-            Ok(proto::key_presence_response::Response::Present)
-        } else {
-            info!(
-                "Did not find session-id {} in kv store during multisig key presence check",
-                request.key_uid
-            );
-            Ok(proto::key_presence_response::Response::Absent)
-        }
+        info!(
+            "[{}] Executing key presence check for multisig",
+            request.key_uid
+        );
+        Ok(proto::key_presence_response::Response::Present)
     }
 }

--- a/src/multisig/key_presence.rs
+++ b/src/multisig/key_presence.rs
@@ -4,7 +4,7 @@
 use super::service::MultisigService;
 
 // logging
-use tracing::info;
+use tracing::debug;
 
 // error handling
 use crate::{proto, TofndResult};
@@ -20,8 +20,8 @@ impl MultisigService {
         // key presence for multisig always returns `Present`.
         // this is done in order to not break compatibility with axelar-core
         // TODO: better handling for multisig key presence.
-        info!(
-            "[{}] Executing key presence check for multisig",
+        debug!(
+            "[{}] key presence check for multisig always return Present",
             request.key_uid
         );
         Ok(proto::key_presence_response::Response::Present)

--- a/src/multisig/keygen.rs
+++ b/src/multisig/keygen.rs
@@ -1,33 +1,16 @@
 use super::service::MultisigService;
 use crate::{proto::KeygenRequest, TofndResult};
-use tofn::{ecdsa::keygen, sdk::api::serialize};
+use tofn::ecdsa::keygen;
 
 use anyhow::anyhow;
 
 impl MultisigService {
     pub(super) async fn handle_keygen(&self, request: &KeygenRequest) -> TofndResult<Vec<u8>> {
-        let session_nonce = request.key_uid.clone();
         let secret_recovery_key = self.kv_manager.seed().await?;
 
-        // generate signing key and verifying key
-        let key_pair = keygen(&secret_recovery_key, session_nonce.as_bytes())
+        let key_pair = keygen(&secret_recovery_key, request.key_uid.as_bytes())
             .map_err(|_| anyhow!("Cannot generate keypair"))?;
 
-        // make reservation for signing key
-        let reservation = self.kv_manager.kv().reserve_key(session_nonce).await?;
-
-        // serialize signing key
-        // SecretScalar is not exposed, so we need to serialize manually here
-        let signing_key_bytes = serialize(key_pair.signing_key())
-            .map_err(|_| anyhow!("Cannot serialize signing key"))?;
-
-        // put signing key into kv store
-        self.kv_manager
-            .kv()
-            .put(reservation, signing_key_bytes)
-            .await?;
-
-        // return verifying key
         Ok(key_pair.encoded_verifying_key().to_vec())
     }
 }

--- a/src/multisig/service.rs
+++ b/src/multisig/service.rs
@@ -27,7 +27,7 @@ impl proto::multisig_server::Multisig for MultisigService {
 
         let response = match self.handle_key_presence(request).await {
             Ok(res) => {
-                info!("Key presence check completed succesfully!");
+                info!("Key presence check completed succesfully");
                 res
             }
             Err(err) => {

--- a/src/multisig/sign.rs
+++ b/src/multisig/sign.rs
@@ -7,16 +7,17 @@ use tofn::ecdsa::{keygen, sign};
 
 impl MultisigService {
     pub(super) async fn handle_sign(&self, request: &SignRequest) -> TofndResult<Vec<u8>> {
+        // re-generate secret key from seed, then sign
         let secret_recovery_key = self.kv_manager.seed().await?;
 
         let key_pair = keygen(&secret_recovery_key, request.key_uid.as_bytes())
-            .map_err(|_| anyhow!("Cannot generate keypair"))?;
+            .map_err(|_| anyhow!("key re-generation failed"))?;
 
         let signature = sign(
             key_pair.signing_key(),
             &request.msg_to_sign.as_slice().try_into()?,
         )
-        .map_err(|_| anyhow!("Cannot generate keypair"))?;
+        .map_err(|_| anyhow!("sign failed"))?;
 
         Ok(signature)
     }

--- a/src/multisig/sign.rs
+++ b/src/multisig/sign.rs
@@ -3,23 +3,21 @@ use crate::{proto::SignRequest, TofndResult};
 use std::convert::TryInto;
 
 use anyhow::anyhow;
-use tofn::{ecdsa::sign, sdk::api::deserialize};
+use tofn::ecdsa::{keygen, sign};
 
 impl MultisigService {
     pub(super) async fn handle_sign(&self, request: &SignRequest) -> TofndResult<Vec<u8>> {
-        // get signing key bytes from kv store
-        let signing_key_bytes = self.kv_manager.kv().get(&request.key_uid).await?;
+        let secret_recovery_key = self.kv_manager.seed().await?;
 
-        // deserialize to signing key
-        // SecretScalar is not exposed, so we need to deserialize manually here
-        let signing_key = deserialize(&signing_key_bytes)
-            .ok_or_else(|| anyhow!("Cannot deserialize SigningKey"))?;
-
-        // get signature
-        let signature = sign(&signing_key, &request.msg_to_sign.as_slice().try_into()?)
+        let key_pair = keygen(&secret_recovery_key, request.key_uid.as_bytes())
             .map_err(|_| anyhow!("Cannot generate keypair"))?;
 
-        // return signature
+        let signature = sign(
+            key_pair.signing_key(),
+            &request.msg_to_sign.as_slice().try_into()?,
+        )
+        .map_err(|_| anyhow!("Cannot generate keypair"))?;
+
         Ok(signature)
     }
 }


### PR DESCRIPTION
Generate multisig keys on-the-fly during `Sign` instead of using the `kv-store` to maintain keys after `Keygen`.
