### PR TITLE
fix: bump version to 0.8.1 to fix --version flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,7 +2132,7 @@ dependencies = [
 
 [[package]]
 name = "tofnd"
-version = "0.7.1"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tofnd"
-version = "0.7.1"
+version = "0.8.1"
 authors = ["Gus Gutoski <gus@axelar.network>", "Stelios Daveas <stelios@axelar.network>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
`tofnd --version` on 0.8.0 currently returns `0.7.1`, which is a bug.  This patch updates `Cargo.toml` and returns `0.8.1`.