### PR TITLE
chore(logs): remove logs and change tofnd return status for logical reserve errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
+name = "exitcode"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
+
+[[package]]
 name = "fastrand"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,6 +2144,7 @@ dependencies = [
  "atty",
  "chacha20poly1305",
  "clap",
+ "exitcode",
  "futures-util",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,10 @@ futures-util = {version = "0.3", default-features = false}
 tiny-bip39 = { version = "0.8.2", default-features = false}
 zeroize = { version = "1.4", features = ["zeroize_derive"], default-features = false}
 
-#error handling
+# error handling
 thiserror = { version = "1.0", default-features = false }
 anyhow = { version = "1.0", default-features = false }
+exitcode =  { version = "1.1", default-features = false }
 
 [build-dependencies]
 tonic-build = {version = "0.5"}

--- a/src/kv_manager/kv.rs
+++ b/src/kv_manager/kv.rs
@@ -16,7 +16,7 @@ use std::{fmt::Debug, path::PathBuf};
 use tokio::sync::{mpsc, oneshot};
 
 // logging
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 #[derive(Clone)]
 pub struct Kv<V> {
@@ -122,7 +122,10 @@ pub fn get_kv_store(
     password: Password,
 ) -> encrypted_sled::Result<encrypted_sled::Db> {
     // create/open DB
-    let kv = encrypted_sled::Db::open(db_name, password)?;
+    let kv = encrypted_sled::Db::open(db_name, password).map_err(|err| {
+        error!("{}", err);
+        err
+    })?;
 
     // log whether the DB was newly created or not
     if kv.was_recovered() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,14 @@ use tokio_stream::wrappers::TcpListenerStream;
 mod encrypted_sled;
 mod gg20;
 mod kv_manager;
+use kv_manager::KvManager;
+mod config;
 mod mnemonic;
 mod multisig;
+use config::parse_args;
 
 // gather logs; need to set RUST_LOG=info
-use tracing::{info, span, Level};
+use tracing::{error, info, span, warn, Level};
 
 // error handling
 pub type TofndResult<Success> = anyhow::Result<Success>;
@@ -18,11 +21,6 @@ pub type TofndResult<Success> = anyhow::Result<Success>;
 pub mod proto {
     tonic::include_proto!("tofnd");
 }
-
-mod config;
-use config::parse_args;
-
-use crate::kv_manager::KvManager;
 
 fn set_up_logs() {
     // enable only tofnd and tofn debug logs - disable serde, tonic, tokio, etc.
@@ -39,12 +37,10 @@ fn set_up_logs() {
 
 #[cfg(feature = "malicious")]
 pub fn warn_for_malicious_build() {
-    use tracing::warn;
     warn!("WARNING: THIS tofnd BINARY AS COMPILED IN 'MALICIOUS' MODE.  MALICIOUS BEHAVIOUR IS INTENTIONALLY INSERTED INTO SOME MESSAGES.  THIS BEHAVIOUR WILL CAUSE OTHER tofnd PROCESSES TO IDENTIFY THE CURRENT PROCESS AS MALICIOUS.");
 }
 
 fn warn_for_unsafe_execution() {
-    use tracing::warn;
     warn!("WARNING: THIS tofnd BINARY IS NOT SAFE: SAFE PRIMES ARE NOT USED BECAUSE '--unsafe' FLAG IS ENABLED.  USE '--unsafe' FLAG ONLY FOR TESTING.");
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,16 @@ fn warn_for_unsafe_execution() {
 /// worker_threads defaults to the number of cpus on the system
 /// https://docs.rs/tokio/1.2.0/tokio/attr.main.html#multi-threaded-runtime
 #[tokio::main(flavor = "multi_thread")]
-async fn main() -> TofndResult<()> {
+async fn main() {
+    match real_main().await {
+        Ok(()) => std::process::exit(exitcode::OK),
+        Err(_) => std::process::exit(exitcode::USAGE),
+    };
+}
+
+async fn real_main() -> TofndResult<()> {
+    set_up_logs();
+
     let cfg = parse_args()?;
 
     // immediately read an encryption password from stdin

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,9 +51,10 @@ async fn main() -> TofndResult<()> {
     let cfg = parse_args()?;
 
     // immediately read an encryption password from stdin
-    let password = cfg.password_method.execute()?;
-
-    set_up_logs();
+    let password = cfg.password_method.execute().map_err(|err| {
+        error!("{}", err);
+        err
+    })?;
 
     // print config warnings
     #[cfg(feature = "malicious")]

--- a/src/mnemonic/cmd_handler.rs
+++ b/src/mnemonic/cmd_handler.rs
@@ -17,7 +17,7 @@ use tofn::gg20::keygen::SecretRecoveryKey;
 
 use rpassword::read_password;
 use std::convert::TryInto;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 // default key to store mnemonic
 const MNEMONIC_KEY: &str = "mnemonic";
@@ -123,7 +123,7 @@ impl KvManager {
             },
             // if we cannot reserve, return failure
             Err(err) => {
-                error!("Cannot reserve mnemonic: {:?}", err);
+                warn!("Cannot reserve mnemonic: {:?}", err);
                 Err(KvErr(err))
             }
         }


### PR DESCRIPTION
Addressing #228 and #250, we need to remove the error logs that are emitted when the mnemonic already exists in the kv-store.
Additionally, map tofnd's errors to exit codes. For now, we can have a single exit code for all errors.