### PR TITLE
fix: ensure that the file is written to

### DIFF
--- a/src/mnemonic/file_io.rs
+++ b/src/mnemonic/file_io.rs
@@ -44,10 +44,14 @@ impl FileIo {
         // delegate zeroization for entropy; no need to worry about mnemonic, it is cleaned automatically
         let mnemonic = bip39_from_entropy(entropy)?;
         let phrase = mnemonic.phrase();
+
         // if there is an existing exported file raise an error
         self.check_if_not_exported()?;
+
         let mut file = std::fs::File::create(&self.export_path())?;
         file.write_all(phrase.as_bytes())?;
+        file.sync_all()?;
+
         info!("Mnemonic written in file {:?}", &self.export_path());
         Ok(())
     }


### PR DESCRIPTION
Audit finding:

Missing Check of file IO Result (Low):
While reviewing the tofnd-main repository, it was noticed that writing the entropy file does not ensure that the whole buffer was successfully written to disk, in particular,
file.write_all() does not ensure that file contents and metadata were successfully written to disk. Filesystems usually work asynchronously and many errors will only arise when the file handle is closed. This also includes errors which denote out of space. When the file object goes out of scope, rust will automatically close the file handle. But Rust’s Drop implementation of std::fs::File then ignores such errors. This can lead to inconsistent state and open the door for further attacks.

Affected File:
tofnd-main/src/mnemonic/file_io.rs