### PR TITLE
chore: make docker create and export cmds equivalent to binary cmds

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ create_mnemonic() {
         return $ERR
     fi
 
-    (echo ${PASSWORD} | tofnd ${ARGS} -m create) && mv $EXPORT_PATH $IMPORT_PATH && echo "... ok" && return $OK
+    (echo ${PASSWORD} | tofnd ${ARGS} -m create) && echo "... ok" && return $OK
     return $ERR
 }
 
@@ -48,7 +48,7 @@ import_mnemonic() {
 # export: export the mnemonic to $EXPORT_PATH, move it to $IMPORT_PATH and exit
 export_mnemonic() {
     echo "Exporting mnemonic ..."
-    echo ${PASSWORD} | tofnd ${ARGS} -m export && mv $EXPORT_PATH $IMPORT_PATH || return $ERR
+    echo ${PASSWORD} | tofnd ${ARGS} -m export || return $ERR
     echo "... ok"
     return $OK
 }
@@ -80,7 +80,7 @@ if [ -n "${MNEMONIC_CMD}" ]; then \
         # Order of set up: 1) import mnemonic, 2) create mnemonic.
         auto)
             echo "Trying import" && import_mnemonic \
-            || (echo "... skipping. Trying to create" && create_mnemonic) \
+            || (echo "... skipping. Trying to create" && create_mnemonic && mv $EXPORT_PATH $IMPORT_PATH) \
             || echo "... skipping"
             ;;
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 OK=0
 ERR=1
 
-# create: create a new mnemonic, export it to a file under the name "import" and continue
+# create: create a new mnemonic and export it to $EXPORT_PATH
 create_mnemonic() {
     echo "Creating mnemonic ..."
 
@@ -19,7 +19,7 @@ create_mnemonic() {
     return $ERR
 }
 
-# import: import a mnemonic from $IMPORT_PATH and continue
+# import: import a mnemonic from $IMPORT_PATH
 import_mnemonic() {
     echo "Importing mnemonic ..."
 
@@ -45,7 +45,7 @@ import_mnemonic() {
     return $OK
 }
 
-# export: export the mnemonic to $EXPORT_PATH, move it to $IMPORT_PATH and exit
+# export: export the mnemonic to $EXPORT_PATH
 export_mnemonic() {
     echo "Exporting mnemonic ..."
     echo ${PASSWORD} | tofnd ${ARGS} -m export || return $ERR
@@ -78,6 +78,7 @@ if [ -n "${MNEMONIC_CMD}" ]; then \
     case ${MNEMONIC_CMD} in
         # auto: try to set up tofnd and then spin up tofnd with the existing mnemonic.
         # Order of set up: 1) import mnemonic, 2) create mnemonic.
+        # If 2) then move the mnemonic to $IMPORT_PATH so that tofnd will not complain
         auto)
             echo "Trying import" && import_mnemonic \
             || (echo "... skipping. Trying to create" && create_mnemonic && mv $EXPORT_PATH $IMPORT_PATH) \


### PR DESCRIPTION
Docker commands `create` and `export` don't rename the exported mnemonic file to `import` (same behaviour as `-m create` and `-m export`).

Docker command `auto` still does the renaming.