### PR TITLE
fix(docker): upgrade image to debian bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN --mount=type=ssh if [ "$features" = "default" ]; then \
   cargo install --locked --features ${features} --path .; \
   fi
 
-FROM debian:buster-slim as runner
+FROM debian:bullseye-slim as runner
 RUN addgroup --system --gid 1001 axelard && adduser --system --uid 1000 --ingroup axelard axelard
 RUN mkdir /.tofnd && chown axelard /.tofnd
 USER axelard


### PR DESCRIPTION
tofnd v0.9.1 was throwing a runtime error due to GLIBC library 2.29 being required but not found. By ugprading the docker image from buster to bullseye, tofnd v0.9.1 now has access to the required version of the library.