### PR TITLE
fix: binary versions for signing

### DIFF
--- a/.github/workflows/build-docker-image-and-binaries.yaml
+++ b/.github/workflows/build-docker-image-and-binaries.yaml
@@ -65,7 +65,7 @@ jobs:
         env:
           SEMVER: ${{ github.event.inputs.tag }}
         run: |
-          gpg --armor --detach-sign  tofnd-linux-amd64-v${SEMVER}
+          gpg --armor --detach-sign  tofnd-linux-amd64-${SEMVER}
 
       - name: Login to DockerHub
         uses: docker/login-action@v1


### PR DESCRIPTION
- `v` is already part of ${SEMVER}
- related: https://github.com/axelarnetwork/axelar-core/pull/1294/files