### PR TITLE
chore(clap): read address from user

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ FLAGS:
     -V, --version        Prints version information
 
 OPTIONS:
+    -a, --address <ip>              [default: 0.0.0.0]
     -d, --directory <directory>     [env: TOFND_HOME=]  [default: .tofnd]
     -m, --mnemonic <mnemonic>       [default: existing]  [possible values: existing, create, import, export]
     -p, --port <port>               [default: 50051]]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,6 +8,7 @@ use anyhow::anyhow;
 const DEFAULT_PATH_ROOT: &str = ".tofnd";
 const TOFND_HOME_ENV_VAR: &str = "TOFND_HOME";
 const DEFAULT_MNEMONIC_CMD: &str = "existing";
+const DEFAULT_IP: &str = "0.0.0.0";
 const DEFAULT_PORT: u16 = 50051;
 const AVAILABLE_MNEMONIC_CMDS: [&str; 4] = ["existing", "create", "import", "export"];
 
@@ -19,6 +20,7 @@ use malicious::*;
 // TODO: move to types.rs
 #[derive(Clone, Debug)]
 pub struct Config {
+    pub ip: String,
     pub port: u16,
     pub safe_keygen: bool,
     pub mnemonic_cmd: Cmd,
@@ -30,6 +32,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
+            ip: DEFAULT_IP.to_string(),
             port: DEFAULT_PORT,
             safe_keygen: true,
             mnemonic_cmd: Cmd::Existing,
@@ -43,11 +46,19 @@ impl Default for Config {
 
 pub fn parse_args() -> TofndResult<Config> {
     // need to use let to avoid dropping temporary value
+    let ip = &DEFAULT_IP.to_string();
     let port = &DEFAULT_PORT.to_string();
 
     let app = App::new("tofnd")
         .about("A threshold signature scheme daemon")
         .version(crate_version!())
+        .arg(
+            Arg::new("ip")
+                .long("ip address")
+                .short('a')
+                .required(false)
+                .default_value(ip),
+        )
         .arg(
             Arg::new("port")
                 .long("port")
@@ -110,6 +121,10 @@ pub fn parse_args() -> TofndResult<Config> {
 
     let matches = app.get_matches();
 
+    let ip = matches
+        .value_of("ip")
+        .ok_or_else(|| anyhow!("ip value"))?
+        .to_string();
     let port = matches
         .value_of("port")
         .ok_or_else(|| anyhow!("port value"))?
@@ -130,6 +145,7 @@ pub fn parse_args() -> TofndResult<Config> {
     };
 
     Ok(Config {
+        ip,
         port,
         safe_keygen,
         mnemonic_cmd,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -54,7 +54,7 @@ pub fn parse_args() -> TofndResult<Config> {
         .version(crate_version!())
         .arg(
             Arg::new("ip")
-                .long("ip address")
+                .long("address")
                 .short('a')
                 .required(false)
                 .default_value(ip),

--- a/src/multisig/tests.rs
+++ b/src/multisig/tests.rs
@@ -1,5 +1,8 @@
 use crate::{
-    addr, encrypted_sled::get_test_password, kv_manager::KvManager, tests::DEFAULT_TEST_IP,
+    addr,
+    encrypted_sled::get_test_password,
+    kv_manager::KvManager,
+    tests::{DEFAULT_TEST_IP, DEFAULT_TEST_PORT},
 };
 use tokio::{
     self,
@@ -40,9 +43,9 @@ async fn spin_test_service_and_client() -> (MultisigClient<Channel>, Sender<()>)
     let service = MultisigServer::new(service);
 
     // create incoming tcp server for service
-    let incoming = TcpListener::bind(addr(DEFAULT_TEST_IP, 0).unwrap())
+    let incoming = TcpListener::bind(addr(DEFAULT_TEST_IP, DEFAULT_TEST_PORT).unwrap())
         .await
-        .unwrap(); // use port 0 and let the OS decide
+        .unwrap();
 
     // create shutdown channels
     let (shutdown_sender, shutdown_receiver) = channel::<()>();

--- a/src/multisig/tests.rs
+++ b/src/multisig/tests.rs
@@ -1,4 +1,6 @@
-use crate::{addr, encrypted_sled::get_test_password, kv_manager::KvManager};
+use crate::{
+    addr, encrypted_sled::get_test_password, kv_manager::KvManager, tests::DEFAULT_TEST_IP,
+};
 use tokio::{
     self,
     net::TcpListener,
@@ -38,7 +40,9 @@ async fn spin_test_service_and_client() -> (MultisigClient<Channel>, Sender<()>)
     let service = MultisigServer::new(service);
 
     // create incoming tcp server for service
-    let incoming = TcpListener::bind(addr(0)).await.unwrap(); // use port 0 and let the OS decide
+    let incoming = TcpListener::bind(addr(DEFAULT_TEST_IP, 0).unwrap())
+        .await
+        .unwrap(); // use port 0 and let the OS decide
 
     // create shutdown channels
     let (shutdown_sender, shutdown_receiver) = channel::<()>();

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -23,6 +23,7 @@ mod malicious;
 use malicious::{MaliciousData, PartyMaliciousData};
 
 mod mnemonic;
+mod socket_address;
 
 use crate::mnemonic::Cmd::{self, Create};
 use proto::message_out::CriminalList;
@@ -47,6 +48,7 @@ lazy_static::lazy_static! {
 }
 const SLEEP_TIME: u64 = 1;
 const MAX_TRIES: u32 = 3;
+pub const DEFAULT_TEST_IP: &str = "0.0.0.0";
 
 struct TestCase {
     uid_count: usize,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -49,6 +49,7 @@ lazy_static::lazy_static! {
 const SLEEP_TIME: u64 = 1;
 const MAX_TRIES: u32 = 3;
 pub const DEFAULT_TEST_IP: &str = "0.0.0.0";
+pub const DEFAULT_TEST_PORT: u16 = 0; // use port 0 and let the OS decide
 
 struct TestCase {
     uid_count: usize,

--- a/src/tests/socket_address.rs
+++ b/src/tests/socket_address.rs
@@ -1,0 +1,13 @@
+//! socket address convertion tests
+
+use crate::addr;
+
+#[test]
+fn test_ips() {
+    let valid_ips = ["0.0.0.0", "127.0.0.1"];
+    let invalid_ips = ["256.0.0.0"];
+    let ports = [0, 65535]; // no need to check for invalid ports because 0 <= u16 <= 65535
+
+    valid_ips.map(|a| ports.map(|p| assert!(addr(a, p).is_ok())));
+    invalid_ips.map(|a| ports.map(|p| assert!(addr(a, p).is_err())));
+}

--- a/src/tests/tofnd_party.rs
+++ b/src/tests/tofnd_party.rs
@@ -4,7 +4,8 @@
 //       produces less friction in the code. Should implement a beeter solution soon.
 
 use super::{
-    mock::SenderReceiver, Deliverer, GrpcKeygenResult, GrpcSignResult, InitParty, Party, MAX_TRIES,
+    mock::SenderReceiver, Deliverer, GrpcKeygenResult, GrpcSignResult, InitParty, Party,
+    DEFAULT_TEST_IP, MAX_TRIES,
 };
 use crate::{
     addr,
@@ -53,13 +54,17 @@ impl TofndParty {
         // start server
         let (server_shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
 
-        let incoming = TcpListener::bind(addr(0)).await.unwrap(); // use port 0 and let the OS decide
+        let incoming = TcpListener::bind(addr(DEFAULT_TEST_IP, 0).unwrap())
+            .await
+            .unwrap(); // use port 0 and let the OS decide
         let server_addr = incoming.local_addr().unwrap();
+        let server_ip = server_addr.ip();
         let server_port = server_addr.port();
         info!("new party bound to port [{:?}]", server_port);
 
         let cfg = Config {
             mnemonic_cmd,
+            ip: server_ip.to_string(),
             port: server_port,
             safe_keygen: false,
             tofnd_path: tofnd_path.to_string(),

--- a/src/tests/tofnd_party.rs
+++ b/src/tests/tofnd_party.rs
@@ -5,7 +5,7 @@
 
 use super::{
     mock::SenderReceiver, Deliverer, GrpcKeygenResult, GrpcSignResult, InitParty, Party,
-    DEFAULT_TEST_IP, MAX_TRIES,
+    DEFAULT_TEST_IP, DEFAULT_TEST_PORT, MAX_TRIES,
 };
 use crate::{
     addr,
@@ -54,9 +54,9 @@ impl TofndParty {
         // start server
         let (server_shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
 
-        let incoming = TcpListener::bind(addr(DEFAULT_TEST_IP, 0).unwrap())
+        let incoming = TcpListener::bind(addr(DEFAULT_TEST_IP, DEFAULT_TEST_PORT).unwrap())
             .await
-            .unwrap(); // use port 0 and let the OS decide
+            .unwrap();
         let server_addr = incoming.local_addr().unwrap();
         let server_ip = server_addr.ip();
         let server_port = server_addr.port();


### PR DESCRIPTION
Allow users to provide the ip address for tofnd using the `-a/--address` flag. `0.0.0.0` remains the default ip if `-a` flag is not specified.