### PR TITLE
chore: change default dir ./.tofnd -> ~/.tofnd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,6 +1701,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom 0.2.3",
+ "redox_syscall",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,6 +2177,7 @@ dependencies = [
  "atty",
  "chacha20poly1305",
  "clap",
+ "dirs",
  "futures-util",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ zeroize = { version = "1.4", features = ["zeroize_derive"], default-features = f
 thiserror = { version = "1.0", default-features = false }
 anyhow = { version = "1.0", default-features = false }
 
+dirs = "4.0"
+
 [build-dependencies]
 tonic-build = {version = "0.6"}
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,10 +20,10 @@ mod malicious;
 use malicious::*;
 
 // default path is ~/.tofnd
-fn default_tofnd_dir() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or(PathBuf::new())
-        .join(DEFAULT_PATH_ROOT)
+fn default_tofnd_dir() -> TofndResult<PathBuf> {
+    Ok(dirs::home_dir()
+        .ok_or_else(|| anyhow!("no home dir"))?
+        .join(DEFAULT_PATH_ROOT))
 }
 
 // TODO: move to types.rs
@@ -38,27 +38,15 @@ pub struct Config {
     #[cfg(feature = "malicious")]
     pub behaviours: Behaviours,
 }
-impl Default for Config {
-    fn default() -> Self {
-        Config {
-            ip: DEFAULT_IP.to_string(),
-            port: DEFAULT_PORT,
-            safe_keygen: true,
-            mnemonic_cmd: Cmd::Existing,
-            tofnd_path: default_tofnd_dir(),
-            password_method: PasswordMethod::Prompt,
-            #[cfg(feature = "malicious")]
-            behaviours: Behaviours::default(),
-        }
-    }
-}
 
 pub fn parse_args() -> TofndResult<Config> {
     // need to use let to avoid dropping temporary value
     let ip = &DEFAULT_IP.to_string();
     let port = &DEFAULT_PORT.to_string();
-    let default_dir = default_tofnd_dir();
-    let default_dir = default_dir.to_str().ok_or_else(|| anyhow!("default dir"))?;
+    let default_dir = default_tofnd_dir()?;
+    let default_dir = default_dir
+        .to_str()
+        .ok_or_else(|| anyhow!("can't convert default dir to str"))?;
 
     let app = App::new("tofnd")
         .about("A threshold signature scheme daemon")

--- a/src/kv_manager/kv.rs
+++ b/src/kv_manager/kv.rs
@@ -31,10 +31,8 @@ where
 {
     /// Creates a new kv service. Returns [InitErr] on failure.
     /// the path of the kvstore is `root_path` + "/kvstore/" + `kv_name`
-    pub fn new(root_path: &str, password: Password) -> KvResult<Self> {
-        let kv_path = PathBuf::from(root_path)
-            .join(DEFAULT_KV_PATH)
-            .join(DEFAULT_KV_NAME);
+    pub fn new(root_path: PathBuf, password: Password) -> KvResult<Self> {
+        let kv_path = root_path.join(DEFAULT_KV_PATH).join(DEFAULT_KV_NAME);
         // use to_string_lossy() instead of to_str() to avoid handling Option<&str>
         let kv_path = kv_path.to_string_lossy().to_string();
         Self::with_db_name(kv_path, password)

--- a/src/kv_manager/value.rs
+++ b/src/kv_manager/value.rs
@@ -20,10 +20,10 @@ pub struct KvManager {
 }
 
 impl KvManager {
-    pub fn new(root: &str, password: Password) -> KvResult<Self> {
+    pub fn new(root: PathBuf, password: Password) -> KvResult<Self> {
         Ok(KvManager {
-            kv: Kv::<KvValue>::new(root, password)?,
-            io: FileIo::new(PathBuf::from(root)),
+            kv: Kv::<KvValue>::new(root.clone(), password)?,
+            io: FileIo::new(root),
         })
     }
     pub fn kv(&self) -> &Kv<KvValue> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ async fn main() -> TofndResult<()> {
 
     let cmd = cfg.mnemonic_cmd.clone();
 
-    let kv_manager = KvManager::new(&cfg.tofnd_path, password)?
+    let kv_manager = KvManager::new(cfg.tofnd_path.clone(), password)?
         .handle_mnemonic(&cfg.mnemonic_cmd)
         .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,13 +51,12 @@ fn warn_for_unsafe_execution() {
 /// https://docs.rs/tokio/1.2.0/tokio/attr.main.html#multi-threaded-runtime
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> TofndResult<()> {
+    set_up_logs(); // can't print any logs until they're set up
     let cfg = parse_args()?;
     let socket_address = addr(&cfg.ip, cfg.port)?;
 
     // immediately read an encryption password from stdin
     let password = cfg.password_method.execute()?;
-
-    set_up_logs();
 
     // print config warnings
     #[cfg(feature = "malicious")]
@@ -69,15 +68,9 @@ async fn main() -> TofndResult<()> {
     // set up span for logs
     let main_span = span!(Level::INFO, "main");
     let _enter = main_span.enter();
-
-    let incoming = TcpListener::bind(socket_address).await?;
-    info!(
-        "tofnd listen addr {:?}, use ctrl+c to shutdown",
-        incoming.local_addr()?
-    );
-
     let cmd = cfg.mnemonic_cmd.clone();
 
+    // TODO why does this step take so long?
     let kv_manager = KvManager::new(cfg.tofnd_path.clone(), password)?
         .handle_mnemonic(&cfg.mnemonic_cmd)
         .await?;
@@ -92,6 +85,12 @@ async fn main() -> TofndResult<()> {
 
     let gg20_service = proto::gg20_server::Gg20Server::new(gg20_service);
     let multisig_service = proto::multisig_server::MultisigServer::new(multisig_service);
+
+    let incoming = TcpListener::bind(socket_address).await?;
+    info!(
+        "tofnd listen addr {:?}, use ctrl+c to shutdown",
+        incoming.local_addr()?
+    );
 
     tonic::transport::Server::builder()
         .add_service(gg20_service)

--- a/src/mnemonic/cmd_handler.rs
+++ b/src/mnemonic/cmd_handler.rs
@@ -192,8 +192,7 @@ mod tests {
     // create a service
     fn get_kv_manager(testdir: PathBuf) -> KvManager {
         // create test dirs
-        let kv_path = testdir.to_str().unwrap();
-        KvManager::new(kv_path, get_test_password()).unwrap()
+        KvManager::new(testdir, get_test_password()).unwrap()
     }
 
     #[traced_test]

--- a/src/multisig/tests.rs
+++ b/src/multisig/tests.rs
@@ -32,7 +32,7 @@ async fn spin_test_service_and_client() -> (MultisigClient<Channel>, Sender<()>)
     let root = testdir!();
 
     // create a kv_manager
-    let kv_manager = KvManager::new(root.to_str().unwrap(), get_test_password())
+    let kv_manager = KvManager::new(root, get_test_password())
         .unwrap()
         .handle_mnemonic(&crate::mnemonic::Cmd::Create)
         .await


### PR DESCRIPTION
At least one validator complained that tofnd's default path is `./.tofnd`.  This PR changes the default path to `$HOME/.tofnd` using the `dirs` crate.

Notes:
* need to change `Config.tofnd_path` type from `String` to `PathBuf` to accommodate `dirs::home_dir`
* unrelated: bind tcp as late as possible
* why is `handle_mnemonic` so slow?
* `cargo clippy` is currently broken on macos: [Clippy crash (version 1.59 on macOS) · Issue #8470 · rust-lang/rust-clippy](https://github.com/rust-lang/rust-clippy/issues/8470)