### PR TITLE
feat: use latest rust in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM rust:1.58.1-bullseye as builder
+FROM rust:latest as builder
 
 RUN set -ex \
   && apt-get update \


### PR DESCRIPTION
the latest build use debian bullseye image 
see : https://hub.docker.com/_/rust

We want to align the version with the binary build that already use the latest binary.