### PR TITLE
feat(entrypoint): add support for rotating mnemonic through docker entrypoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,8 @@ copy-binary-from-image: guard-SEMVER
 upload-binaries-to-s3: guard-S3_PATH
 	aws s3 cp ./bin ${S3_PATH}/ --recursive
 
-.PHONY: docker-image-all
-docker-image-all: git-submodule-setup
-	make docker-image
-	make docker-image-malicious
+.PHONY: all
+all: git-submodule-setup docker-image docker-image-malicious
 
 .PHONY: git-submodule-setup
 git-submodule-setup:


### PR DESCRIPTION
The following changes were introduced:

- some issues/recommendations around usage of quotes, leveraging arrays for args, using < instead of piping input etc. came from shellcheck. the file now passes shellcheck
- added a rotate_mnemonic function. This function is called before running the daemon in auto mode if mnemonic exists already
- the function checks for a file called `rotate` in tofnd home. if found, it will rotate the key and delete the `rotate` file. if not found it will skip rotation
- this makes it easy to rotate the mnemonic. we simply have to add a file in tofnd home and thats it. 