### PR TITLE
fix(build): use fixed version of rust base image for binary build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM rust:latest as builder
+FROM rust:1.58.1-bullseye as builder
 
 RUN set -ex \
   && apt-get update \


### PR DESCRIPTION
Revert "use latest rust in Dockerfile (#282)"
This reverts commit 5f680da55b6c7ee9c9b5e6ed79eb61d46d84419d.

Quick fix for following error. 
`tofnd: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by tofnd)`