### PR TITLE
fix: revert rpassword dep version

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @axelarnetwork/core
-* @milapsheth @sdaveas
+* @axelarnetwork/core @milapsheth @sdaveas

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,23 +1426,12 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.3.1"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
 dependencies = [
  "libc",
- "rtoolbox",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rtoolbox"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
+ "winapi",
 ]
 
 [[package]]
@@ -1817,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "tofnd"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tofnd"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Interoplabs Eng <eng@interoplabs.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ dirs = { version = "5.0", default-features = false }
 # kv store encryption
 chacha20poly1305 = { version = "0.10", features = ["alloc"], default-features = false }
 rand = { version = "0.8", default-features = false }
-rpassword = { version = "7.3", default-features = false }
+rpassword = { version = "5.0", default-features = false } # future versions don't support reading both from stdin and tty at the same time
 scrypt = { version = "0.11", default-features = false, features = ["std"] }
 
 # gRPC server


### PR DESCRIPTION
Switch back to `rpassword v5` which supports reading from stdin or tty at the same time